### PR TITLE
Fix-release-on-tag

### DIFF
--- a/.github/workflows/release-on-tag-push.yaml
+++ b/.github/workflows/release-on-tag-push.yaml
@@ -16,19 +16,6 @@ jobs:
         id: package
         uses: codex-team/action-nodejs-package-info@v1
 
-      - name: Generate postman collection for service
-        uses: actions/setup-node@v2
-        with:
-          node-version: '20'
-
-      - name: Set File name
-        uses: myci-actions/export-env-var@1
-        with:
-          name: P_COLLECTION_FILE_NAME
-          value: ${{ steps.package.outputs.name }}-v${{ steps.package.outputs.version }}-postman-collection.json
-
-      - run: 'npx openapi-to-postmanv2 -s openapi3.yaml -o ${{ env.P_COLLECTION_FILE_NAME }}'
-
       - name: Publish Release to Github
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
1. I removed the openapi check in the workflow: "release-on-tag-push" because there is no openapi.
2. I added changelog for workflow: ""release-on-tag-push"

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                       |