### PR TITLE
chore: bump 3d-file-syncer image to v2.1.2 (MAPCO-9268)

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -96,7 +96,7 @@ revisionHistoryLimit: 5 # Amount of revisions we keep
 
 image:
   repository: file-syncer
-  tag: latest
+  tag: v2.1.2
 
 extraVolumes: {}
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -96,7 +96,7 @@ revisionHistoryLimit: 5 # Amount of revisions we keep
 
 image:
   repository: file-syncer
-  tag: v2.1.2
+  tag:
 
 extraVolumes: {}
 


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                  |

